### PR TITLE
net472, net6.0, net7.0 are added as build targets.

### DIFF
--- a/source/Src/Common/Common.csproj
+++ b/source/Src/Common/Common.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net6.0;net7.0</TargetFrameworks>
 
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(Version).$(Revision)</FileVersion>
@@ -32,12 +32,12 @@
     <PackageReference Include="Unity.Interception" Version="$(UnityInterceptionVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard')) AND !$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.Install" />
   </ItemGroup>
@@ -111,7 +111,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <Compile Remove="Instrumentation\*.cs" />
   </ItemGroup>
 

--- a/source/Src/Common/Configuration/Design/ResourceCategoryAttribute.cs
+++ b/source/Src/Common/Configuration/Design/ResourceCategoryAttribute.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.Common.Configuration.Design
 
     }
 
-#if NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
+#if NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NET6_0  || NET7_0
 
     internal sealed class SRCategoryAttribute : CategoryAttribute
     {

--- a/source/Src/Common/Configuration/SystemConfigurationSource.cs
+++ b/source/Src/Common/Configuration/SystemConfigurationSource.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.Common.Configuration
         {
             try
             {
-#if !NETSTANDARD2_0 && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2
+#if !NETSTANDARD2_0 && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NET6_0  && !NET7_0
                 return AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
 #else
                 //ToDo: Find the most correct solution

--- a/source/Src/Common/Properties/AssemblyInfo.cs
+++ b/source/Src/Common/Properties/AssemblyInfo.cs
@@ -7,7 +7,10 @@ using System.Security;
 using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
 using Microsoft.Practices.EnterpriseLibrary.Common.Configuration.Design;
 
+#if !NET6_0 && !NET7_0
 [assembly: ReliabilityContract(Consistency.WillNotCorruptState, Cer.None)]
+#endif
+
 [assembly: AllowPartiallyTrustedCallers]
 
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Added net472, net6.0, net7.0 ad build targets to Common, Validation and Logging blocks. Unlike net standard builds it allows to include some windows functionality like event log code.